### PR TITLE
db: Allow configuring database via URL

### DIFF
--- a/src/passari_workflow/db/connection.py
+++ b/src/passari_workflow/db/connection.py
@@ -11,11 +11,19 @@ def get_connection_uri():
     """
     Get the connection URI used to connect to the database
     """
+    url = CONFIG["db"].get("url")
     user = CONFIG["db"].get("user")
     password = CONFIG["db"].get("password", "")
     host = CONFIG["db"].get("host")
     port = CONFIG["db"].get("port")
-    name = CONFIG["db"]["name"]
+    name = CONFIG["db"].get("name")
+
+    if url and not name:
+        return url
+    elif not url and not name:
+        raise EnvironmentError("Either 'url' or 'name' is required for db")
+    elif url and name:
+        raise EnvironmentError("The db 'url' and 'name' are exclusive")
 
     if user and host and port:
         return f"postgresql://{user}:{quote_plus(password)}@{host}:{port}/{name}"


### PR DESCRIPTION
Make it possible to configure the database connection with an URL, since that is usually simpler to specify than the 5 different values for user, password, host, port and name.