### PR TITLE
Fix test DB initialization

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,8 @@
-pytest
-sftpserver
-fakeredis
-freezegun
-pytest-asyncio
-pytest-cov
-pytest-postgresql
-lupa
+pytest~=8.3.4
+sftpserver~=0.3
+fakeredis~=2.26.1
+freezegun~=1.5.1
+pytest-asyncio~=0.24.0
+pytest-cov~=6.0.0
+pytest-postgresql~=6.1.1
+lupa~=2.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,7 +79,13 @@ def database(request):
 
         version = get_psql_version()
 
-        with DatabaseJanitor(user, host, port, db_name, version):
+        with DatabaseJanitor(
+            user=user,
+            host=host,
+            port=port,
+            dbname=db_name,
+            version=version
+        ):
             create_engine(
                 f"postgresql://{user}@{host}:{port}/{db_name}"
             )


### PR DESCRIPTION
The DatabaseJanitor class from pytest-postgresql only accepts keyword arguments as of v6.0.0.

Also pin the dev requirements to the latest working versions.