### PR TITLE
Fix test DB connection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def database(request):
 
 @pytest.fixture(scope="function")
 def engine(database, monkeypatch):
+    monkeypatch.setitem(CONFIG["db"], "url", "")
     monkeypatch.setitem(CONFIG["db"], "user", database.user)
     monkeypatch.setitem(
         CONFIG["db"], "password",


### PR DESCRIPTION
Since the database name and URL are exclusive in
get_connection_uri, clear the configured URL before calling get_connection_uri for the test database.