### PR TITLE
Improve the test worker run script (run_test.sh)

### DIFF
--- a/run_test.sh
+++ b/run_test.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
+# Run the RQ workers in the background for testing purposes.
+#
+# Note: This script is intended for testing purposes only.  In
+# production the workers should be started with a process manager like
+# systemd.
+
 rq worker download_object &
 rq worker create_sip &
 rq worker submit_sip &
-echo "Press anything to shutdown the workers";
-read -n 1
-killall -s TERM rq
+
+# Wait a bit for workers to start and stop outputting to console
+sleep 1
+
+printf "\nWorkers started:\n%s\n\n" "$(jobs -l)"
+printf "Press Ctrl+C to shutdown the workers.\n"
+while true; do sleep 10; done
+
+# Note: Workers will stop when the script is terminated with Ctrl+C
+# because they are background jobs and the script is the parent process.


### PR DESCRIPTION
Add some documentation to the script, list the started jobs with the "jobs -l" command and make the script stop only on Ctrl+C (to allow typing to the terminal without killing the workers).