### PR TITLE
Add dev requirements to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "fakeredis[lua]",
+    "freezegun",
+    "pytest",
+    "pytest-asyncio",
+    "sftpserver",
+    "sqlalchemy-utils",
+]
 docs = ["sphinxcontrib-apidoc"]
 
 [project.scripts]


### PR DESCRIPTION
List the development requirents as with package extra feature named "dev".  This allows installing them with `pip install .[dev]` or listing them in input file for pip-compile.