### PR TITLE
redis: Fix connection URL reading from config file

### DIFF
--- a/src/passari_workflow/redis/connection.py
+++ b/src/passari_workflow/redis/connection.py
@@ -30,6 +30,8 @@ def get_redis_url():
         )
     elif url and (host or port or db or password):
         raise EnvironmentError("The 'url' config for Redis is exclusive")
+    elif url:
+        return url
 
     password_part = f":{quote(password)}@" if password else ""
     port_part = f":{port}" if port else ""


### PR DESCRIPTION
The previous commit (bfc981f) was missing an elif branch and therefore the code didn't read the "url" configuration option from the config file at all.  Fix that.