### PR TITLE
sync scripts: Use asyncio.run instead of get_event_loop

### DIFF
--- a/src/passari_workflow/scripts/sync_attachments.py
+++ b/src/passari_workflow/scripts/sync_attachments.py
@@ -223,8 +223,7 @@ async def sync_attachments(offset=0, limit=None, save_progress=False):
 def cli(offset, limit, save_progress):
     connect_db()
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(
+    asyncio.run(
         sync_attachments(
             offset=offset, limit=limit, save_progress=save_progress
         )

--- a/src/passari_workflow/scripts/sync_objects.py
+++ b/src/passari_workflow/scripts/sync_objects.py
@@ -221,8 +221,7 @@ async def sync_objects(offset=0, limit=None, save_progress=False):
 def cli(offset, limit, save_progress):
     connect_db()
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(
+    asyncio.run(
         sync_objects(
             offset=offset, limit=limit, save_progress=save_progress
         )


### PR DESCRIPTION
Replace the asyncio.get_event_loop() followed by run_until_complete(...) call with the asyncio.run(...), because it makes the code cleaner and works even if the event loop in the main thread has been cleared.

This fixes an issue with pytest-asyncio 0.25.2 which seems to clear the main thread event loop sometimes.  The tests on sync_attachments and sync_objects used to fail if all tests were ran in the same pytest call, but if only those sync tests are selected (e.g. with `pytest -k test_sync`) then the tests used to pass.  After this change they seem to pass on both cases.

This might be the same issue as described in [1] (even if it is only for Python 3.9, but our issue happens with Python 3.12) or not.

[1] https://github.com/pytest-dev/pytest-asyncio/issues/1039