### PR TITLE
Tests: Rename the SIP source dir from sip to data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,9 +221,9 @@ def local_museum_package_factory(museum_package_factory, museum_packages_dir):
 
         # Create the local directory
         package_dir = museum_packages_dir / str(package.museum_object.id)
-        (package_dir / "sip" / "reports").mkdir(parents=True)
+        (package_dir / "data" / "reports").mkdir(parents=True)
         (package_dir / "logs").mkdir()
-        (package_dir / "sip" / "reports" / "Object.xml").write_text(
+        (package_dir / "data" / "reports" / "Object.xml").write_text(
             OBJECT_XML_TEMPLATE.format(object_id=package.museum_object.id)
         )
 

--- a/tests/jobs/test_create_sip.py
+++ b/tests/jobs/test_create_sip.py
@@ -198,7 +198,7 @@ def test_preservation_error(
         )
 
     # Create the fake museum package directory
-    (museum_packages_dir / "123456" / "sip").mkdir(parents=True)
+    (museum_packages_dir / "123456" / "data").mkdir(parents=True)
     (museum_packages_dir / "123456" / "reports").mkdir(parents=True)
 
     monkeypatch.setattr(

--- a/tests/jobs/test_download_object.py
+++ b/tests/jobs/test_download_object.py
@@ -151,7 +151,7 @@ def test_preservation_error(
         )
 
     # Create the fake museum package directory
-    (museum_packages_dir / "123456" / "sip").mkdir(parents=True)
+    (museum_packages_dir / "123456" / "data").mkdir(parents=True)
 
     monkeypatch.setattr(
         "passari_workflow.jobs.download_object.main",

--- a/tests/scripts/test_freeze_objects.py
+++ b/tests/scripts/test_freeze_objects.py
@@ -138,8 +138,8 @@ def test_freeze_objects_existing_dirs(
     museum_object_factory(id=123456)
     museum_object_factory(id=654321)
 
-    (museum_packages_dir / "123456" / "sip" / "reports").mkdir(parents=True)
-    (museum_packages_dir / "654321" / "sip" / "reports").mkdir(parents=True)
+    (museum_packages_dir / "123456" / "data" / "reports").mkdir(parents=True)
+    (museum_packages_dir / "654321" / "data" / "reports").mkdir(parents=True)
 
     freeze_objects([
         "--delete-jobs", "--reason", "Test reason", "654321", "123456"

--- a/tests/scripts/test_reset_workflow.py
+++ b/tests/scripts/test_reset_workflow.py
@@ -40,9 +40,9 @@ def test_reset_workflow(
     )
     object_c.latest_package = package_c
 
-    (museum_packages_dir / "10" / "sip").mkdir(parents=True)
-    (museum_packages_dir / "20" / "sip").mkdir(parents=True)
-    (museum_packages_dir / "30" / "sip").mkdir(parents=True)
+    (museum_packages_dir / "10" / "data").mkdir(parents=True)
+    (museum_packages_dir / "20" / "data").mkdir(parents=True)
+    (museum_packages_dir / "30" / "data").mkdir(parents=True)
 
     session.commit()
 

--- a/tests/scripts/test_sync_processed_sips.py
+++ b/tests/scripts/test_sync_processed_sips.py
@@ -74,7 +74,7 @@ def test_sync_processed_sips_accepted(
         sync_processed_sips):
     # Create local package directory
     museum_packages_dir.joinpath("123456", "logs").mkdir(parents=True)
-    museum_packages_dir.joinpath("123456", "sip", "reports").mkdir(
+    museum_packages_dir.joinpath("123456", "data", "reports").mkdir(
         parents=True
     )
 
@@ -106,7 +106,7 @@ def test_sync_processed_sips_accepted(
     report_path = Path(__file__).parent.resolve() / "data" / "Object.xml"
     shutil.copyfile(
         report_path,
-        museum_packages_dir / "123456" / "sip" / "reports" / "Object.xml"
+        museum_packages_dir / "123456" / "data" / "reports" / "Object.xml"
     )
 
     db_museum_object = MuseumObject(
@@ -167,7 +167,7 @@ def test_sync_processed_sips_rejected(
         sync_processed_sips, museum_package_factory, museum_object):
     # Create local package directory
     museum_packages_dir.joinpath("123456", "logs").mkdir(parents=True)
-    museum_packages_dir.joinpath("123456", "sip", "reports").mkdir(
+    museum_packages_dir.joinpath("123456", "data", "reports").mkdir(
         parents=True
     )
 
@@ -180,7 +180,7 @@ def test_sync_processed_sips_rejected(
     report_path = Path(__file__).parent.resolve() / "data" / "Object.xml"
     shutil.copyfile(
         report_path,
-        museum_packages_dir / "123456" / "sip" / "reports" / "Object.xml"
+        museum_packages_dir / "123456" / "data" / "reports" / "Object.xml"
     )
 
     db_museum_package = museum_package_factory(
@@ -249,7 +249,7 @@ def test_sync_processed_sips_skipped(
     # Create local package directory
     for object_id in range(0, 5):
         (museum_packages_dir / str(object_id) / "logs").mkdir(parents=True)
-        (museum_packages_dir / str(object_id) / "sip" / "reports").mkdir(
+        (museum_packages_dir / str(object_id) / "data" / "reports").mkdir(
             parents=True
         )
 
@@ -263,7 +263,7 @@ def test_sync_processed_sips_skipped(
         report_path = Path(__file__).parent.resolve() / "data" / "Object.xml"
         shutil.copyfile(
             report_path,
-            museum_packages_dir / str(object_id) / "sip" / "reports"
+            museum_packages_dir / str(object_id) / "data" / "reports"
             / "Object.xml"
         )
 


### PR DESCRIPTION
The data directory inside the SIP was renamed in passari: https://github.com/andersinno/passari/pull/9/commits/7b60d96

Refs MPZ-5